### PR TITLE
Fix the missing `autoAdjustmentFilters` in iOS 9

### DIFF
--- a/Source/Filters/NBUCoreImageFilterProvider.m
+++ b/Source/Filters/NBUCoreImageFilterProvider.m
@@ -292,8 +292,9 @@
             // Auto adjust off?
             if (![filter boolValueForKey:@"autoAdjust"])
                 continue;
-            
-            NSArray * autoFilters = [ciImage autoAdjustmentFilters];
+
+            // `autoAdjustmentFilters` is not available in iOS 9.0 and later.
+            NSArray * autoFilters = [ciImage autoAdjustmentFiltersWithOptions:nil];
             NBULogVerbose(@"Applying auto adjustment filters: %@", autoFilters);
             for (ciFilter in autoFilters)
             {


### PR DESCRIPTION
It is only [available in iOS 5.0 through iOS 8.4](https://developer.apple.com/library/ios/documentation/GraphicsImaging/Reference/QuartzCoreFramework/Classes/CIImage_Class/#//apple_ref/occ/instm/CIImage/autoAdjustmentFilters) according to #15. I just replace it with `autoAdjustmentFiltersWithOptions:` to build with iOS 9 SDK

I leave out other diffs made by running pod install to simplify this modification. Please have a look, thanks. 
